### PR TITLE
SLING-11873 sling-mock-oak: Improve oak-jcr dependency exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,20 @@
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.jackrabbit</groupId>
-                    <artifactId>jackrabbit-api</artifactId>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.annotation</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.service.component.annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.service.metatype.annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-11873